### PR TITLE
Add `status` to orders?

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE Orders (
     customer_id INT,
     order_date DATE,
     total_amount DECIMAL(10, 2),
+    status VARCHAR(20), -- Cart / Pending / Completed
     FOREIGN KEY (customer_id) REFERENCES Customers(customer_id)
 );
 


### PR DESCRIPTION
I think we might be able to just add a `status` field to Orders in order to use this as both a Cart and Transaction Log functionality. 

Cart orders will have `status = 'Cart'` and completed transactions can have `status = 'Complete'` or something like that.

To get user's current cart we can query `customer_id = user && status = 'Cart'`

To get all transaction history we can query `status = 'Complete'` 

Lmk what you think